### PR TITLE
Fix broken markdown URL for static front page

### DIFF
--- a/src/Discovery/AlternateLinkHandler.php
+++ b/src/Discovery/AlternateLinkHandler.php
@@ -78,12 +78,35 @@ class AlternateLinkHandler {
         }
 
         // Build the .md URL.
-        $md_url = rtrim( get_permalink( $post ), '/' ) . '.md';
+        $md_url = $this->build_markdown_url( $post );
 
         // Output the alternate link tag.
         printf(
             '<link rel="alternate" type="text/markdown" href="%s" />' . "\n",
             esc_url( $md_url )
         );
+    }
+
+    /**
+     * Build the markdown URL for a given post.
+     *
+     * For the static front page, the permalink is the site root (e.g. https://example.com/)
+     * so appending .md would produce an invalid URL. Instead, we use a filterable
+     * slug (default "index") to produce e.g. https://example.com/index.md.
+     *
+     * @param \WP_Post $post The post to build the URL for.
+     * @return string The markdown URL.
+     */
+    private function build_markdown_url( \WP_Post $post ): string {
+        $permalink = get_permalink( $post );
+
+        // Detect if this is the static front page by comparing to site URL.
+        $site_url = trailingslashit( home_url() );
+        if ( trailingslashit( $permalink ) === $site_url ) {
+            $front_slug = apply_filters( 'markdown_alternate_front_page_slug', 'index' );
+            return $site_url . $front_slug . '.md';
+        }
+
+        return rtrim( $permalink, '/' ) . '.md';
     }
 }


### PR DESCRIPTION
## Summary

Fixes #5.

- When a static page is set as the front page, `get_permalink()` returns the site root URL (e.g. `https://example.com/`). The existing `rtrim('/') . '.md'` logic produces an invalid URL like `https://example.com.md`.
- This fix detects the front page case and generates `/index.md` instead. The slug is filterable via a new `markdown_alternate_front_page_slug` filter (default: `"index"`).
- Three locations are fixed: `AlternateLinkHandler::output_alternate_link()`, `RewriteHandler::handle_accept_negotiation()`, and `RewriteHandler::parse_markdown_url()`.

## Test plan

- [ ] Set a static page as the front page (Settings → Reading)
- [ ] Visit the front page and inspect the HTML `<head>` — verify the `<link rel="alternate">` points to `/index.md` (not `example.com.md`)
- [ ] Visit `/index.md` directly — verify it serves the front page as markdown
- [ ] Send a request with `Accept: text/markdown` to the front page — verify it redirects to `/index.md`
- [ ] Verify existing `.md` URLs for regular posts/pages still work
- [ ] Test the `markdown_alternate_front_page_slug` filter to change "index" to e.g. "home"

🤖 Generated with [Claude Code](https://claude.com/claude-code)