### PR TITLE
fix: resolve static front page .md URL generation (#5)

### DIFF
--- a/src/Discovery/AlternateLinkHandler.php
+++ b/src/Discovery/AlternateLinkHandler.php
@@ -7,6 +7,8 @@
 
 namespace MarkdownAlternate\Discovery;
 
+use MarkdownAlternate\Router\UrlConverter;
+
 /**
  * Handles alternate link tag injection in HTML page head.
  *
@@ -47,27 +49,6 @@ class AlternateLinkHandler {
         return in_array( $post_type, $this->get_supported_post_types(), true );
     }
 
-    /**
-     * Convert a permalink to a markdown URL.
-     *
-     * Handles special case for front page to avoid .com.md URLs.
-     *
-     * @param string $permalink The permalink to convert.
-     * @return string The markdown URL.
-     */
-    private function convert_to_markdown_url( string $permalink ): string {
-        // Normalize both URLs by removing trailing slashes for comparison
-        $normalized_permalink = rtrim( $permalink, '/' );
-        $normalized_home      = rtrim( home_url( '/' ), '/' );
-
-        // If this is the front page, use /index.md
-        if ( $normalized_permalink === $normalized_home ) {
-            return home_url( '/index.md' );
-        }
-
-        // Otherwise, append .md to the permalink
-        return $normalized_permalink . '.md';
-    }
 
     /**
      * Output alternate link tag for markdown version.
@@ -100,7 +81,7 @@ class AlternateLinkHandler {
         }
 
         // Build the .md URL.
-        $md_url = $this->convert_to_markdown_url( get_permalink( $post ) );
+        $md_url = UrlConverter::convert_to_markdown_url( get_permalink( $post ) );
 
         // Output the alternate link tag.
         printf(

--- a/src/Router/UrlConverter.php
+++ b/src/Router/UrlConverter.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * URL conversion utilities for markdown alternate URLs.
+ *
+ * @package MarkdownAlternate
+ */
+
+namespace MarkdownAlternate\Router;
+
+/**
+ * Utility class for converting permalinks to markdown URLs.
+ */
+class UrlConverter {
+
+	/**
+	 * Convert a permalink to a markdown URL.
+	 *
+	 * Handles special case for front page to avoid .com.md URLs.
+	 *
+	 * @param string $permalink The permalink to convert.
+	 * @return string The markdown URL.
+	 */
+	public static function convert_to_markdown_url( string $permalink ): string {
+		// Normalize both URLs by removing trailing slashes for comparison
+		$normalized_permalink = rtrim( $permalink, '/' );
+		$normalized_home      = rtrim( home_url( '/' ), '/' );
+
+		// If this is the front page, use /index.md
+		if ( $normalized_permalink === $normalized_home ) {
+			return home_url( '/index.md' );
+		}
+
+		// Otherwise, append .md to the permalink
+		return $normalized_permalink . '.md';
+	}
+}


### PR DESCRIPTION
Closes #5

## Summary

Fixes invalid markdown URL generation when a static page is configured as the front page.

## Problem

When a static page is set as the front page (Settings → Reading), `get_permalink()` returns the site root (e.g., `https://example.com/`). The plugin was appending `.md` directly, resulting in `https://example.com.md`, which looks like an invalid TLD.

## Solution

- Detect when a permalink is the site root (front page)
- Convert to `/index.md` instead of `.md`
- Added special routing logic to handle `/index.md` requests
- Added rewrite rule for `index.md`

## Changes

- **AlternateLinkHandler**: Added `convert_to_markdown_url()` method to generate proper markdown URLs
- **RewriteHandler**: Added matching `convert_to_markdown_url()` method for Accept header negotiation
- **RewriteHandler**: Added special case handling in `parse_markdown_url()` for `/index.md`
- **RewriteHandler**: Added dedicated rewrite rule for `^index\.md$`

## Test Plan

- [ ] Set a static page as front page (Settings → Reading)
- [ ] Verify `<link rel="alternate">` in HTML shows `https://example.com/index.md`
- [ ] Verify `Accept: text/markdown` on front page redirects to `/index.md`
- [ ] Verify `/index.md` serves front page content as markdown
- [ ] Verify `/.md` returns 404 (does not resolve to front page)
- [ ] Verify regular posts/pages still work correctly with `.md` URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)