### PR TITLE
refactor: simplify plugin activation and remove duplicate rewrite registration

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -67,7 +67,8 @@ class Plugin {
      * @return void
      */
     public static function activate(): void {
-        RewriteHandler::register_rules();
+        $handler = new RewriteHandler();
+        $handler->add_rewrite_rules();
         flush_rewrite_rules();
     }
 

--- a/src/Router/RewriteHandler.php
+++ b/src/Router/RewriteHandler.php
@@ -391,15 +391,4 @@ class RewriteHandler {
         return null;
     }
 
-    /**
-     * Register rewrite rules statically.
-     *
-     * Used by activation hook to ensure rules are registered before flush.
-     *
-     * @return void
-     */
-    public static function register_rules(): void {
-        $handler = new self();
-        $handler->add_rewrite_rules();
-    }
 }


### PR DESCRIPTION
## Summary

Simplifies the plugin activation flow and removes code duplication between `Plugin::activate()` and `RewriteHandler::register_rules()`.

## Changes

- Removed `RewriteHandler::register_rules()` static method (single-use abstraction)
- Updated `Plugin::activate()` to instantiate `RewriteHandler` directly instead of calling static method
- Eliminates DRY violation where rewrite registration logic existed in two places
- Maintains identical functionality - rules still registered on activation and on every init hook

## Testing

- [x] Plugin activates without errors
- [x] `.md` URLs work after activation
- [x] Plugin deactivates cleanly
- [x] Rewrite rules flush properly
- [x] No changes to runtime behavior

## Why This Improves the Code

1. **Removes unnecessary abstraction** - The static `register_rules()` method existed solely for the activation hook and created an awkward instantiation pattern
2. **Improves consistency** - Activation now follows the same pattern as the constructor (instantiate → call instance method)
3. **Reduces maintenance burden** - One less method to maintain, clearer flow from activation → rewrite registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)