### PR TITLE
refactor: simplify YoastLlmsTxt by merging duplicate rewrite methods

### DIFF
--- a/src/Integration/YoastLlmsTxt.php
+++ b/src/Integration/YoastLlmsTxt.php
@@ -36,8 +36,8 @@ class YoastLlmsTxt {
         // Wrap each trigger that causes Yoast to (re)generate the llms.txt file.
         // Priority 9 = before Yoast's priority 10, priority 11 = after.
         foreach ( [ 'update_option_wpseo', 'update_option_wpseo_llmstxt', 'wpseo_llms_txt_population' ] as $action ) {
-            add_action( $action, [ $this, 'start' ], 9 );
-            add_action( $action, [ $this, 'stop' ], 11 );
+            add_action( $action, [ $this, 'start' ], 9, 0 );
+            add_action( $action, [ $this, 'stop' ], 11, 0 );
         }
     }
 

--- a/src/Integration/YoastLlmsTxt.php
+++ b/src/Integration/YoastLlmsTxt.php
@@ -65,7 +65,7 @@ class YoastLlmsTxt {
 
         // from_post() fallback path: uses get_permalink() directly.
         add_filter( 'post_link', [ $this, 'rewrite_post_link' ], 10, 2 );
-        add_filter( 'page_link', [ $this, 'rewrite_page_link' ], 10, 2 );
+        add_filter( 'page_link', [ $this, 'rewrite_post_link' ], 10, 2 );
         add_filter( 'post_type_link', [ $this, 'rewrite_post_link' ], 10, 2 );
     }
 
@@ -82,7 +82,7 @@ class YoastLlmsTxt {
 
         remove_filter( 'wpseo_canonical', [ $this, 'rewrite_canonical' ], 10 );
         remove_filter( 'post_link', [ $this, 'rewrite_post_link' ], 10 );
-        remove_filter( 'page_link', [ $this, 'rewrite_page_link' ], 10 );
+        remove_filter( 'page_link', [ $this, 'rewrite_post_link' ], 10 );
         remove_filter( 'post_type_link', [ $this, 'rewrite_post_link' ], 10 );
     }
 
@@ -110,32 +110,17 @@ class YoastLlmsTxt {
     }
 
     /**
-     * Rewrite post/CPT permalink to .md.
+     * Rewrite post/page/CPT permalink to .md.
      *
-     * Works for both post_link and post_type_link filters.
+     * Handles post_link, page_link, and post_type_link filters.
+     * get_post_type() accepts both a WP_Post object and an integer post ID.
      *
-     * @param string   $url  The permalink.
-     * @param \WP_Post $post The post object.
+     * @param string          $url       The permalink.
+     * @param \WP_Post|int    $post      The post object or post ID.
      * @return string
      */
     public function rewrite_post_link( $url, $post ): string {
         $post_type = get_post_type( $post );
-        if ( ! $post_type || ! PostTypeSupport::is_supported( $post_type ) ) {
-            return $url;
-        }
-
-        return rtrim( $url, '/' ) . '.md';
-    }
-
-    /**
-     * Rewrite page permalink to .md.
-     *
-     * @param string $url     The page URL.
-     * @param int    $post_id The page ID.
-     * @return string
-     */
-    public function rewrite_page_link( $url, $post_id ): string {
-        $post_type = get_post_type( $post_id );
         if ( ! $post_type || ! PostTypeSupport::is_supported( $post_type ) ) {
             return $url;
         }

--- a/src/Integration/YoastLlmsTxt.php
+++ b/src/Integration/YoastLlmsTxt.php
@@ -35,18 +35,10 @@ class YoastLlmsTxt {
     public function register(): void {
         // Wrap each trigger that causes Yoast to (re)generate the llms.txt file.
         // Priority 9 = before Yoast's priority 10, priority 11 = after.
-
-        // 1. Feature toggle (enable/disable llms.txt in Yoast settings).
-        add_action( 'update_option_wpseo', [ $this, 'start' ], 9 );
-        add_action( 'update_option_wpseo', [ $this, 'stop' ], 11 );
-
-        // 2. llms.txt page selection settings change.
-        add_action( 'update_option_wpseo_llmstxt', [ $this, 'start' ], 9 );
-        add_action( 'update_option_wpseo_llmstxt', [ $this, 'stop' ], 11 );
-
-        // 3. Weekly cron regeneration.
-        add_action( 'wpseo_llms_txt_population', [ $this, 'start' ], 9 );
-        add_action( 'wpseo_llms_txt_population', [ $this, 'stop' ], 11 );
+        foreach ( [ 'update_option_wpseo', 'update_option_wpseo_llmstxt', 'wpseo_llms_txt_population' ] as $action ) {
+            add_action( $action, [ $this, 'start' ], 9 );
+            add_action( $action, [ $this, 'stop' ], 11 );
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

- Removes `rewrite_page_link`, which was functionally identical to `rewrite_post_link` — same body, same logic, different parameter name only
- Routes the `page_link` filter to `rewrite_post_link` instead, since `get_post_type()` accepts both a `WP_Post` object and an integer post ID
- Updates the `rewrite_post_link` docblock to reflect that it now handles all three permalink filters (`post_link`, `page_link`, `post_type_link`)

## Test plan

- [ ] Verify page URLs get `.md` appended during llms.txt generation
- [ ] Verify post URLs get `.md` appended during llms.txt generation
- [ ] Verify CPT URLs get `.md` appended during llms.txt generation
- [ ] Confirm all three filters are properly removed after `stop()` is called (no filter leakage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)