### PR TITLE
Fix ?format=markdown for static front pages

### DIFF
--- a/src/Router/RewriteHandler.php
+++ b/src/Router/RewriteHandler.php
@@ -247,11 +247,21 @@ class RewriteHandler {
             return;
         }
 
-        if (!is_singular()) {
-            return;
-        }
+        $post = null;
 
-        $post = get_queried_object();
+        if (is_singular()) {
+            $post = get_queried_object();
+        } elseif ('page' === get_option('show_on_front')) {
+            // Static front page: the extra ?format= query var can prevent
+            // WordPress from recognising the request as singular, so it falls
+            // back to the blog-post index.
+            if (is_front_page() || is_home()) {
+                $page_on_front = (int) get_option('page_on_front');
+                if ($page_on_front) {
+                    $post = get_post($page_on_front);
+                }
+            }
+        }
 
         if (!$post instanceof WP_Post) {
             return;

--- a/src/Router/RewriteHandler.php
+++ b/src/Router/RewriteHandler.php
@@ -251,15 +251,13 @@ class RewriteHandler {
 
         if (is_singular()) {
             $post = get_queried_object();
-        } elseif ('page' === get_option('show_on_front')) {
+        } elseif ('page' === get_option('show_on_front') && (is_front_page() || is_home())) {
             // Static front page: the extra ?format= query var can prevent
             // WordPress from recognising the request as singular, so it falls
             // back to the blog-post index.
-            if (is_front_page() || is_home()) {
-                $page_on_front = (int) get_option('page_on_front');
-                if ($page_on_front) {
-                    $post = get_post($page_on_front);
-                }
+            $page_on_front = (int) get_option('page_on_front');
+            if ($page_on_front) {
+                $post = get_post($page_on_front);
             }
         }
 


### PR DESCRIPTION
## Summary

- When a site uses a static front page (Settings > Reading > "A static page"), `?format=markdown` on the home URL returned the blog post listing instead of the front page content
- The `is_singular()` check in `handle_format_parameter()` fails because the extra `?format=` query var prevents WordPress from recognizing the request as singular
- Added fallback detection: when `is_singular()` is false and the site has a static front page configured, check `is_front_page()` / `is_home()` and resolve via `page_on_front` option

Closes #35

## Test plan

- [ ] `curl "http://site.test/?format=markdown"` returns static front page content (not blog listing)
- [ ] `curl "http://site.test/sample-page/?format=markdown"` still works for regular pages
- [ ] `curl "http://site.test/index.md"` still works (unaffected `.md` URL path)
- [ ] Sites without a static front page are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)